### PR TITLE
Multiattack action missing name in Action List

### DIFF
--- a/EngineeringSuite/NPC/Controllers/ActionController.cs
+++ b/EngineeringSuite/NPC/Controllers/ActionController.cs
@@ -82,7 +82,7 @@ namespace EngineeringSuite.NPC.Controllers
             if(actionIndex == 1)
             {
                 // Check to see if Multiattack exists;  If it does, leave it at the 'top'
-                if (!npcActions[0].ActionName.Equals(Multiattack.ActionName))
+                if (!npcActions[0].ActionName.Equals(Multiattack.LocalActionName))
                 {
                     npcActions.Move(actionIndex, actionIndex - 1);
                 }
@@ -98,7 +98,7 @@ namespace EngineeringSuite.NPC.Controllers
             ObservableCollection<ActionModelBase> npcActions = GetNPCModel().NPCActions;
 
             //Ignore trying to move a Multiattack
-            if (action.ActionName.Equals(Multiattack.ActionName))
+            if (action.ActionName.Equals(Multiattack.LocalActionName))
             {
                 return; //no-op
             }

--- a/EngineeringSuite/NPC/Models/Action/Multiattack.cs
+++ b/EngineeringSuite/NPC/Models/Action/Multiattack.cs
@@ -8,14 +8,16 @@ namespace EngineeringSuite.NPC.Models.Action
 {
     public class Multiattack : ActionModelBase
     {
-        public const string ActionName = "Multiattack";
+        public new const string LocalActionName = "Multiattack";
 
         public Multiattack()
         {
+            ActionName = LocalActionName;
         }
 
         public Multiattack(string description)
         {
+            ActionName = LocalActionName;
             this.ActionDescription = description;
         }
 

--- a/EngineeringSuite/NPC/UserControls/LairActions/LairActionControl.xaml.cs
+++ b/EngineeringSuite/NPC/UserControls/LairActions/LairActionControl.xaml.cs
@@ -34,7 +34,7 @@ namespace EngineeringSuite.NPC.UserControls.LairActions
             var thisDataContext = (sender as Button).DataContext;
             if (thisDataContext is Models.Action.LairActions)
             {
-                actionController.UpdateLairAction((Models.Action.LairActions)thisDataContext);
+                actionController.UpdateLairAction(CommonMethod.CloneJson((Models.Action.LairActions)thisDataContext));
             }
         }
     }

--- a/EngineeringSuite/NPC/UserControls/LairActions/OptionsControl.xaml
+++ b/EngineeringSuite/NPC/UserControls/LairActions/OptionsControl.xaml
@@ -11,7 +11,7 @@
             <Label Content="Options" Foreground="Gray"  HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" FontWeight="Bold"/>
             <StackPanel Orientation="Horizontal">
                 <Label Content="Options:" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0" Margin="35,5,0,0" />
-                <TextBox Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0" Margin="10,5,0,0" Height="60" TextWrapping="Wrap" VerticalScrollBarVisibility="Visible" />
+                <TextBox Text="{Binding ActionDescription}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0" Margin="10,5,0,0" Height="60" TextWrapping="Wrap" VerticalScrollBarVisibility="Visible" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="20,20,0,0">
                 <Button Content="Add/Update" Height="20" Width="100" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0" Margin="0,0,0,0" Click="AddButton_Click"/>

--- a/EngineeringSuite/NPC/UserControls/LairActions/OptionsControl.xaml.cs
+++ b/EngineeringSuite/NPC/UserControls/LairActions/OptionsControl.xaml.cs
@@ -39,7 +39,7 @@ namespace EngineeringSuite.NPC.UserControls.LairActions
             var thisDataContext = (sender as Button).DataContext;
             if (thisDataContext is Models.Action.LairActions)
             {
-                actionController.UpdateLairAction((Models.Action.LairActions)thisDataContext);
+                actionController.UpdateLairAction(CommonMethod.CloneJson((Models.Action.LairActions)thisDataContext));
             }
         }
     }


### PR DESCRIPTION
Overriding the ActionName in Multiattack did not work as expected

Refactored so Multiattack const value has unique name & constructors update ActionName accordingly

Fixes #22 