### PR TITLE
LairAction - Other Action Description missing from Action List

### DIFF
--- a/EngineeringSuite/NPC/Controllers/ActionController.cs
+++ b/EngineeringSuite/NPC/Controllers/ActionController.cs
@@ -115,9 +115,9 @@ namespace EngineeringSuite.NPC.Controllers
             npcActions.Move(actionIndex, actionIndex + 1);
         }
 
-        public void RaiseActionInLairActionList(Models.Action.LairActions action)
+        public void RaiseActionInLairActionList(LairAction action)
         {
-            ObservableCollection<Models.Action.LairActions> lairActions = GetNPCModel().LairActions;
+            ObservableCollection<LairAction> lairActions = GetNPCModel().LairActions;
 
             int actionIndex = lairActions.IndexOf(action);
             if (actionIndex == 0)
@@ -130,9 +130,9 @@ namespace EngineeringSuite.NPC.Controllers
             }
         }
 
-        public void LowerActionInLairActionsList(Models.Action.LairActions action)
+        public void LowerActionInLairActionsList(LairAction action)
         {
-            ObservableCollection<Models.Action.LairActions> lairActions = GetNPCModel().LairActions;
+            ObservableCollection<LairAction> lairActions = GetNPCModel().LairActions;
 
             int actionIndex = lairActions.IndexOf(action);
 
@@ -147,25 +147,27 @@ namespace EngineeringSuite.NPC.Controllers
         }
 
 
-        public void UpdateLairAction(Models.Action.LairActions lairAction)
+        public void UpdateLairAction(LairAction lairAction)
         {
             NPCModel npcModel = GetNPCModel();
-            ObservableCollection<LairActions> LairActions = npcModel.LairActions;
-            var obj = LairActions.FirstOrDefault(x => x.ActionName == lairAction.ActionName);
+
+            LairAction cloneLairAction = CommonMethod.CloneJson(lairAction);
+            ObservableCollection<LairAction> LairActions = npcModel.LairActions;
+            var obj = LairActions.FirstOrDefault(x => x.ActionName == cloneLairAction.ActionName);
             if (obj != null)
             {
-                lairAction.ActionID = obj.ActionID;
+                cloneLairAction.ActionID = obj.ActionID;
                 LairActions.Remove(obj);
-                LairActions.Add(lairAction);
+                LairActions.Add(cloneLairAction);
             }
             else
             {
-                lairAction.ActionID = LairActions.Count;
-                LairActions.Add(lairAction);
+                cloneLairAction.ActionID = LairActions.Count;
+                LairActions.Add(cloneLairAction);
             }
         }
 
-        public void RemoveLairAction(Models.Action.LairActions lairAction)
+        public void RemoveLairAction(LairAction lairAction)
         {
             GetNPCModel().LairActions.Remove(lairAction);
         }

--- a/EngineeringSuite/NPC/Models/Action/LairAction.cs
+++ b/EngineeringSuite/NPC/Models/Action/LairAction.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace EngineeringSuite.NPC.Models.Action
 {
-    public class LairActions : ActionModelBase
+    public class LairAction : ActionModelBase
     {
     }
 }

--- a/EngineeringSuite/NPC/Models/NPCModel.cs
+++ b/EngineeringSuite/NPC/Models/NPCModel.cs
@@ -147,6 +147,6 @@ namespace EngineeringSuite.NPC
 
         public ObservableCollection<ActionModelBase> NPCActions { get; } = new ObservableCollection<ActionModelBase>();
 
-        public ObservableCollection<Models.Action.LairActions> LairActions { get; } = new ObservableCollection<Models.Action.LairActions>();
+        public ObservableCollection<LairAction> LairActions { get; } = new ObservableCollection<LairAction>();
     }
 }

--- a/EngineeringSuite/NPC/UserControls/LairActions/LairActionControl.xaml.cs
+++ b/EngineeringSuite/NPC/UserControls/LairActions/LairActionControl.xaml.cs
@@ -22,7 +22,7 @@ namespace EngineeringSuite.NPC.UserControls.LairActions
     /// </summary>
     public partial class LairActionControl : UserControl
     {
-        public Models.Action.LairActions LairAction { get; set; } = new Models.Action.LairActions();
+        public LairAction LairAction { get; set; } = new LairAction();
         public LairActionControl()
         {
             InitializeComponent();
@@ -32,9 +32,9 @@ namespace EngineeringSuite.NPC.UserControls.LairActions
         {
             ActionController actionController = new ActionController();
             var thisDataContext = (sender as Button).DataContext;
-            if (thisDataContext is Models.Action.LairActions)
+            if (thisDataContext is LairAction)
             {
-                actionController.UpdateLairAction((Models.Action.LairActions)thisDataContext);
+                actionController.UpdateLairAction((LairAction)thisDataContext);
             }
         }
     }

--- a/EngineeringSuite/NPC/UserControls/LairActions/OptionsControl.xaml
+++ b/EngineeringSuite/NPC/UserControls/LairActions/OptionsControl.xaml
@@ -11,7 +11,7 @@
             <Label Content="Options" Foreground="Gray"  HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" FontWeight="Bold"/>
             <StackPanel Orientation="Horizontal">
                 <Label Content="Options:" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0" Margin="35,5,0,0" />
-                <TextBox Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0" Margin="10,5,0,0" Height="60" TextWrapping="Wrap" VerticalScrollBarVisibility="Visible" />
+                <TextBox Text="{Binding ActionDescription}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0" Margin="10,5,0,0" Height="60" TextWrapping="Wrap" VerticalScrollBarVisibility="Visible" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="20,20,0,0">
                 <Button Content="Add/Update" Height="20" Width="100" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0" Margin="0,0,0,0" Click="AddButton_Click"/>

--- a/EngineeringSuite/NPC/UserControls/LairActions/OptionsControl.xaml.cs
+++ b/EngineeringSuite/NPC/UserControls/LairActions/OptionsControl.xaml.cs
@@ -22,7 +22,7 @@ namespace EngineeringSuite.NPC.UserControls.LairActions
     /// </summary>
     public partial class OptionsControl : UserControl
     {
-        public Models.Action.LairActions LairAction { get; set; } = new Models.Action.LairActions();
+        public LairAction LairAction { get; set; } = new LairAction();
 
         public const string ActionName = "Options";
 
@@ -37,9 +37,9 @@ namespace EngineeringSuite.NPC.UserControls.LairActions
         {
             ActionController actionController = new ActionController();
             var thisDataContext = (sender as Button).DataContext;
-            if (thisDataContext is Models.Action.LairActions)
+            if (thisDataContext is LairAction)
             {
-                actionController.UpdateLairAction((Models.Action.LairActions)thisDataContext);
+                actionController.UpdateLairAction(thisDataContext as LairAction);
             }
         }
     }

--- a/EngineeringSuite/NPC/Views/ViewLairActions.xaml.cs
+++ b/EngineeringSuite/NPC/Views/ViewLairActions.xaml.cs
@@ -25,7 +25,7 @@ namespace EngineeringSuite.NPC
     public partial class ViewLairActions : Window
     {
         private ActionController actionController;
-        public ObservableCollection<Models.Action.LairActions> NpcLairActions { get; set; }
+        public ObservableCollection<LairAction> NpcLairActions { get; set; }
         public ViewLairActions()
         {
             InitializeComponent();
@@ -59,9 +59,9 @@ namespace EngineeringSuite.NPC
             if (sender is OverviewControl)
             {
                 var action = (sender as OverviewControl).DataContext;
-                if (action is Models.Action.LairActions)
+                if (action is LairAction)
                 {
-                    actionController.RaiseActionInLairActionList(action as Models.Action.LairActions);
+                    actionController.RaiseActionInLairActionList(action as LairAction);
                 }
             }
         }
@@ -71,9 +71,9 @@ namespace EngineeringSuite.NPC
             if (sender is OverviewControl)
             {
                 var action = (sender as OverviewControl).DataContext;
-                if (action is Models.Action.LairActions)
+                if (action is LairAction)
                 {
-                    actionController.LowerActionInLairActionsList(action as Models.Action.LairActions);
+                    actionController.LowerActionInLairActionsList(action as LairAction);
                 }
             }
         }
@@ -83,9 +83,9 @@ namespace EngineeringSuite.NPC
             if (sender is OverviewControl)
             {
                 var action = (sender as OverviewControl).DataContext;
-                if (action is Models.Action.LairActions)
+                if (action is LairAction)
                 {
-                    actionController.RemoveLairAction(action as Models.Action.LairActions);
+                    actionController.RemoveLairAction(action as LairAction);
                 }
             }
         }
@@ -95,9 +95,9 @@ namespace EngineeringSuite.NPC
             if (sender is OverviewControl)
             {
                 var action = (sender as OverviewControl).DataContext;
-                if (action is Models.Action.LairActions)
+                if (action is LairAction)
                 {
-                    var lairAction = (action as Models.Action.LairActions);
+                    var lairAction = (action as LairAction);
                     if (lairAction.ActionName.Equals(OptionsControl.ActionName))
                     {
                         lairOptions.IsChecked = true;


### PR DESCRIPTION
Fixes #20 

Renamed the class name 'LairActions' back to 'LairAction' to match the class file name;

Added missing binding on the Options textbox to ActionDescription